### PR TITLE
trading: make search results include highest price, rather than exclude

### DIFF
--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -143,21 +143,21 @@ class Trading:
         async with self.bot.pool.acquire() as conn:
             if itemtype == "All":
                 ret = await conn.fetch(
-                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE m."price"<$1 AND (ai."damage">=$2 OR ai."armor">=$3);',
+                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE m."price"<=$1 AND (ai."damage">=$2 OR ai."armor">=$3);',
                     highestprice,
                     minstat,
                     minstat,
                 )
             elif itemtype == "Sword":
                 ret = await conn.fetch(
-                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE ai."type"=$1 AND ai."damage">=$2 AND m."price"<$3;',
+                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE ai."type"=$1 AND ai."damage">=$2 AND m."price"<=$3;',
                     itemtype,
                     minstat,
                     highestprice,
                 )
             elif itemtype == "Shield":
                 ret = await conn.fetch(
-                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE ai."type"=$1 AND ai."armor">=$2 AND m."price"<$3;',
+                    'SELECT * FROM allitems ai JOIN market m ON (ai.id=m.item) WHERE ai."type"=$1 AND ai."armor">=$2 AND m."price"<=$3;',
                     itemtype,
                     minstat,
                     highestprice,


### PR DESCRIPTION
Currently, `$shop`'s `highestprice` parameter is exclusive, meaning that if you search for items that cost up to $150 for example, it only shows you items costing $149 or less. Items that cost exactly $150, which is presumably within your specified "budget" of $150, do not show up. I don't know very much about SQL, but perhaps this fixes that issue. :)

![market](https://user-images.githubusercontent.com/5206120/51583518-0f275e00-1f25-11e9-8161-0107852c6344.png)