### PR TITLE
marriage.py: only respond in same channel as event

### DIFF
--- a/cogs/marriage.py
+++ b/cogs/marriage.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands
 import cogs.rpgtools as rpgtools
-from discord.ext.commands import BucketType
 import random
 import traceback
 from utils.checks import *
@@ -374,6 +373,7 @@ To buy one of these items for your partner, use `{ctx.prefix}spoil shopid`
             def check(msg):
                 return (
                     msg.author.id in [ctx.author.id, marriage]
+                    and msg.channel.id == ctx.channel.id
                     and len(msg.content) <= 20
                 )
 


### PR DESCRIPTION
I remember seeing a bug in the #bug-report channel saying that the bot would listen anywhere for a new child name. This resulted in cases where the user (or their partner) sent a message in a completely different channel - or even guild, if they shared multiple guilds with IdleRPG - and that would cause the child to be renamed. Hopefully, this might fix that.

Using `channel` should preserve DM behaviour without an additional check, as DM channels also have IDs that can be checked in the same way as a guild channel.

(Also, I don't see `BucketType` being used anywhere in this file - is the import needed?)