### PR TITLE
reset cooldown if non-donator message appears

### DIFF
--- a/cogs/classes.py
+++ b/cogs/classes.py
@@ -113,6 +113,7 @@ class Classes:
                 "Please align as a `Warrior`, `Mage`, `Thief`, `Ranger` or `Paragon` (Patreon Only)."
             )
         if profession == "Paragon" and not is_patron(self.bot, ctx.author):
+            await self.bot.reset_cooldown(ctx)
             return await ctx.send("You have to be a donator to choose this class.")
         if profession == "Paragon":
             profession = "Novice"


### PR DESCRIPTION
I've seen some people having an issue where, if they haven't yet been given the Donator tag and they try to switch classes to Paragon, they end up having to wait 24 hours to try again, even if they get the Donator tag within that time. This should reset the cooldown so they can try again when the donation and everything have been processed.