### PR TITLE
trading.py: fix typo in remove command

### DIFF
--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -128,7 +128,7 @@ class Trading:
                 "INSERT INTO inventory (item, equipped) VALUES ($1, $2);", itemid, False
             )
         await ctx.send(
-            f"Successfully remove item `{itemid}` from the shop and put it in your inventory."
+            f"Successfully removed item `{itemid}` from the shop and put it in your inventory."
         )
 
     @commands.command(


### PR DESCRIPTION
It should say "item removed", not "item remove". :)