### PR TITLE
adventure.py: fix check for adventure number

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -95,7 +95,11 @@ class Adventure:
                 )
 
             def msgcheck(amsg):
-                return amsg.channel == ctx.channel and not amsg.author.bot
+                return (
+                    amsg.channel == ctx.channel
+                    and amsg.author.id == ctx.author.id
+                    and not amsg.author.bot
+                )
 
             browsing = True
             while browsing:


### PR DESCRIPTION
Currently, if one person hits the :1234: reaction that causes the bot to ask for an adventure number, _anyone_ can type in a number and the bot will use it. This should restrict the listener to only the user who actually triggered the `$adventures` command.