### PR TITLE
(maybe) better inventory title

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -216,7 +216,7 @@ class Profile(commands.Cog):
 
     async def invembed(self, ctx, ret):
         result = discord.Embed(
-            title=f"{ctx.author.nick}'s inventory includes", colour=discord.Colour.blurple()
+            title=f"{ctx.author.display_name}'s inventory includes", colour=discord.Colour.blurple()
         )
         for weapon in ret:
             if weapon[7]:
@@ -248,7 +248,7 @@ class Profile(commands.Cog):
             allitems = list(chunks(ret, 5))
             currentpage = 0
             maxpage = len(allitems) - 1
-            result = await self.invembed(allitems[currentpage])
+            result = await self.invembed(ctx, allitems[currentpage])
             result.set_footer(text=f"Page {currentpage+1} of {maxpage+1}")
             msg = await ctx.send(embed=result)
             if maxpage == 0:

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -214,9 +214,9 @@ class Profile(commands.Cog):
             f"You currently have **{points} XP**, which means you are on Level **{rpgtools.xptolevel(points)}**. Missing to next level: **{rpgtools.xptonextlevel(points)}**"
         )
 
-    async def invembed(self, ret):
+    async def invembed(self, ctx, ret):
         result = discord.Embed(
-            title="Your inventory includes", colour=discord.Colour.blurple()
+            title=f"{ctx.author.nick}'s inventory includes", colour=discord.Colour.blurple()
         )
         for weapon in ret:
             if weapon[7]:


### PR DESCRIPTION
For crowded times, when multiple people want to see their items, the inventories might be hard to distinguish from one another, as most people don't know their items by heart.
I simply changed the `invembed` to include the person's nickname, though it might also be possible to use the character name instead.