### PR TITLE
An effort to make raids global

### DIFF
--- a/cogs/raid.py
+++ b/cogs/raid.py
@@ -381,7 +381,9 @@ Use https://raid.travitia.xyz/ to join the raid!
         
     @commands.command()
     async def raid(self, ctx):
-        await ctx.send("Did you ever want to join together with other players to defeat the dragon that roams this land? Raids got you covered!\n Join the support server (`$support`) for more information.")
-
+        await ctx.send(
+            "Did you ever want to join together with other players to defeat the dragon that roams this land? Raids got you covered!\nJoin the support server (`$support`) for more information.")
+        )
+        
 def setup(bot):
     bot.add_cog(Raid(bot))

--- a/cogs/raid.py
+++ b/cogs/raid.py
@@ -76,21 +76,6 @@ Use https://raid.travitia.xyz/ to join the raid!
 """,
             file=discord.File("assets/other/dragon.jpg"),
         )
-        channels = await conn.fetch(
-            'SELECT channels FROM raids'
-        )
-        for notified_id in channels:
-            notified = await self.bot.get_channel(notified_id)
-            try:
-                await notified.send(
-                    f"""
-**ATTENTION! ZEREKIEL HAS SPAWNED!**
-This boss has {boss['hp']} HP and has high-end loot!
-The dragon will be vulnerable in 15 Minutes
-Use https://raid.travitia.xyz/ to join the raid!
-"""             )
-            except:
-                pass
         try:
             await self.bot.get_channel(506_133_354_874_404_874).send(
                 "@everyone Zerekiel spawned! 15 Minutes until he is vulnerable...\nUse https://raid.travitia.xyz/ to join the raid!"
@@ -394,53 +379,9 @@ Use https://raid.travitia.xyz/ to join the raid!
             f"**{ctx.author.mention}'s raid multipliers**\nDamage Multiplier: x{atk} (Upgrading: ${atkp})\nDefense Multiplier: x{deff} (Upgrading: ${deffp})"
         )
         
-    @commands.group(invoke_without_command=True)
-    async def raidnotif(self, ctx):
-        await ctx.send("Please use either `activate` or `deactivate` as a subcommand.")
-        
-    @raidnotif.command()
-    async def activate(self, ctx):
-        """Enters the channel this command is run in to the notified channels for raids"""
-        def mycheck(msg):
-            return (
-                msg.content.strip() == "accept" and amsg.author == ctx.author
-            )
-         await ctx.send(
-            f"This will notify this channel with an everyone ping when a raid starts.\nType `accept` to confirm.\n\nNOTE: this channel to be pinged should be private to avoid frustration with some members"
-        )
-        try:
-            await self.bot.wait_for("message", timeout=15, check=mycheck)
-        except asyncio.TimeoutError:
-            return await ctx.send("Notification activation cancelled")
-        async with self.bot.pool.acquire() as conn:
-                await conn.execute(
-                    "INSERT INTO raids (channels) VALUES ($1)", ctx.channel.id
-                )
-         await ctx.send(
-            f"Successfully added {ctx.channel} into the notified channels list."
-         )
-        
-    @raidnotif.command()
-    async def deactivate(self, ctx):
-        """Removes the channel this command is run in from the notified channels for raids."""
-        def mycheck(msg):
-            return (
-                msg.content.strip() == "accept" and amsg.author == ctx.author
-            )
-         await ctx.send(
-            f"This will no longer notify this channel with an everyone ping when a raid starts.\nType `accept` to confirm."
-        )
-        try:
-            await self.bot.wait_for("message", timeout=15, check=mycheck)
-        except asyncio.TimeoutError:
-            return await ctx.send("Notification activation cancelled")
-        async with self.bot.pool.acquire() as conn:
-                await conn.execute(
-                    'DELETE FROM raids WHERE "channel"=$1', ctx.channel.id
-                )
-         await ctx.send(
-            f"Successfully added {ctx.channel} into the notified channels list."
-         )
+    @commands.command()
+    async def raid(self, ctx):
+        await ctx.send("Did you ever want to join together with other players to defeat the dragon that roams this land? Raids got you covered!\n Join the support server (`$support`) for more information.")
 
 def setup(bot):
     bot.add_cog(Raid(bot))

--- a/cogs/raid.py
+++ b/cogs/raid.py
@@ -382,7 +382,7 @@ Use https://raid.travitia.xyz/ to join the raid!
     @commands.command()
     async def raid(self, ctx):
         await ctx.send(
-            "Did you ever want to join together with other players to defeat the dragon that roams this land? Raids got you covered!\nJoin the support server (`$support`) for more information.")
+            f"Did you ever want to join together with other players to defeat the dragon that roams this land? Raids got you covered!\nJoin the support server (`{ctx.prefix}support`) for more information.")
         )
         
 def setup(bot):


### PR DESCRIPTION
New commands `raidnotif activate/deactivate` will send the boss spawn message to the channels in a new table `raids`. Any channel where activate is run in will be added to that database and when a raid happens, all the channel will be notified.
*at least that's the idea...*

I'll need someone to double- and triple-check before it's put into action. Also, this would require you to create a new table called raids. There's definitely room for improvement on my part, but let me know what you think though :)