### PR TITLE
miscellaneous.py: Remove x > n dice requirement

### DIFF
--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -291,9 +291,7 @@ However, as work on this is not done and code not clean, v3.5 will come by time,
         if len(dice_type) != 2:
             return await ctx.send("Use the ndx format.")
         if dice_type[0] > 100:
-            return await ctx.send("Too many dices.")
-        if dice_type[1] > dice_type[0]:
-            return await ctx.send("The second number should be bigger than the first!")
+            return await ctx.send("Too many dice.")
         results = []
         for _ in range(dice_type[0]):
             results.append(random.randint(1, dice_type[1]))


### PR DESCRIPTION
Firstly, `dice_type[1] > dice_type[0]` would be checking if the second number is greater than the first, and if it is true, then the bot complains that the second number should be bigger than the first - even though it is.

But I'm not sure why this requirement is here at all anyway - I don't see why the number of dice can't be greater than the number of sides on each die.

Minor typo fix as well: `dice` is already the plural, no need for "dices". :)