### PR TITLE
better link for signing up for raids

### DIFF
--- a/cogs/raid.py
+++ b/cogs/raid.py
@@ -73,13 +73,13 @@ class Raid(commands.Cog):
 **ATTENTION! ZEREKIEL HAS SPAWNED!**
 This boss has {boss['hp']} HP and has high-end loot!
 The dragon will be vulnerable in 15 Minutes
-Use https://raid.travitia.xyz/ to join the raid!
+Use https://raid.travitia.xyz/login to join the raid!
 """,
             file=discord.File("assets/other/dragon.jpg"),
         )
         try:
             await self.bot.get_channel(506_133_354_874_404_874).send(
-                "@everyone Zerekiel spawned! 15 Minutes until he is vulnerable...\nUse https://raid.travitia.xyz/ to join the raid!"
+                "@everyone Zerekiel spawned! 15 Minutes until he is vulnerable...\nUse https://raid.travitia.xyz/login to join the raid!"
             )
         except discord.Forbidden:
             await ctx.channel.set_permissions(


### PR DESCRIPTION
I heard some complaints about the link on `raid.travitia.xyz` is too small and when testing myself, some mobile browsers don't allow zooming in, for exmple the built-in browser for Parallel Space.
The new link would redirect to the Discord Authorization page. If no raid is running, it will still notify the user after the authorization.
Alternatively, use the Discord searchbar with `from: Chippy#7628 has: file` to find raidjoin.html which is a small idea/motivation to get a raid join button for this website. It might need a custom made button though, as the one I added just looks *awful*.
In any case, let me know what you think of this idea.