### PR TITLE
Fixed daily rewards for streaks over 10

### DIFF
--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -39,7 +39,7 @@ class Miscellaneous(commands.Cog):
         await self.bot.redis.execute(
             "EXPIRE", f"idle:daily:{ctx.author.id}", 48 * 60 * 60
         )  # 48h: after 2 days, they missed it
-        money = 2 ** (streak % 11 - 1) * 50
+        money = 2 ** (streak % 10 - 1) * 100
         await self.bot.pool.execute(
             'UPDATE profile SET money=money+$1 WHERE "user"=$2;', money, ctx.author.id
         )


### PR DESCRIPTION
Previously would reset to 25 credits on day 11, then day 22, day 33, etc.
Now it should reset to 50 credits on days 10, 20, 30, etc.