### PR TITLE
profile: Restore description for $give

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -419,6 +419,7 @@ class Profile(commands.Cog):
     async def give(
         self, ctx, money: IntFromTo(0, 100000000), other: MemberWithCharacter
     ):
+        """Gift money!"""
         if other == ctx.author:
             return await ctx.send("No cheating!")
         if ctx.character_data["money"] < money:


### PR DESCRIPTION
The description for the `give` command was accidentally removed in [this commit](https://github.com/Gelbpunkt/IdleRPG/commit/53f3349726e08f685e0b4bcb0fbf25f86b82c346#diff-47938d9bf1e161eec8a10fe0088a8919L429).