### PR TITLE
tournament.py: Prevent bot from joining tournaments

### DIFF
--- a/cogs/tournament.py
+++ b/cogs/tournament.py
@@ -41,6 +41,7 @@ class Tournament(commands.Cog):
                 r.message.id == msg.id
                 and u not in participants
                 and str(r.emoji) == "\U00002694"
+                and not u.bot
             )
 
         while acceptingentries:


### PR DESCRIPTION
Idle is currently joining tournaments started by users, when it adds the reaction.