### PR TITLE
trading.py: Fix inconsistency in error message

### DIFF
--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -38,7 +38,7 @@ class Trading(commands.Cog):
                 )
             elif price > item["value"] * 1000:
                 return await ctx.send(
-                    f"Your price is too high. Try adjusting it to be up to `{item[6] * 50}`."
+                    f"Your price is too high. Try adjusting it to be up to `{item[6] * 1000}`."
                 )
             await conn.execute(
                 "DELETE FROM inventory i USING allitems ai WHERE i.item=ai.id AND ai.id=$1 AND ai.owner=$2;",


### PR DESCRIPTION
The `if` statement says that you can sell items for up to 1000x the item's value, but the error message still shows the limit of 50x the value. This should make the error message consistent with the actual limit.