### PR TITLE
trading.py: restore description of $shop

### DIFF
--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -132,6 +132,7 @@ class Trading(commands.Cog):
         minstat: float = 0.00,
         highestprice: IntGreaterThan(-1) = 1_000_000,
     ):
+        """Show the market with all items and prices."""
         if itemtype not in ["All", "Sword", "Shield"]:
             return await ctx.send(
                 "Use either `All`, `Sword` or `Shield` as a type to filter for."


### PR DESCRIPTION
Looks like this was removed by accident [in this commit](https://github.com/Gelbpunkt/IdleRPG/commit/70951bb171ddcb8dabff47c68033bce0b6a8d5e4).