### PR TITLE
Mention price of item upgrade during confirmation

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -336,10 +336,11 @@ class Profile(commands.Cog):
                 f"You are too poor to upgrade this item. The upgrade costs **${pricetopay}**, but you only have **${ctx.character_data['money']}**."
             )
 
-        if not await ctx.confirm(f"Are you sure to upgrade this item: {item['name']}?"):
+        if not await ctx.confirm(f"Are you sure you want to upgrade this item: {item['name']}? It will cost **${pricetopay}**."):
             await self.bot.reset_cooldown(ctx)
             return await ctx.send("Weapon upgrade cancelled.")
         if not await checks.has_money(self.bot, ctx.author.id, pricetopay):
+            await self.bot.reset_cooldown(ctx)
             return await ctx.send("You're too poor.")
         async with self.bot.pool.acquire() as conn:
             await conn.execute(


### PR DESCRIPTION
Noticed a lot of people pointing out that `$upgrade` now doesn't tell you in advance how much the upgrade will cost. This should fix that.

Also, reset the cooldown if the user doesn't have enough money.