### PR TITLE
server.py: Fix display of ID in $serverinfo

### DIFF
--- a/cogs/server.py
+++ b/cogs/server.py
@@ -57,7 +57,7 @@ Server created at: `{created_at}`"""
                 members=ctx.guild.member_count,
                 urltext=urltext,
                 owner=ctx.guild.owner.mention,
-                id=id,
+                id=ctx.guild.id,
                 created_at=ctx.guild.created_at.__format__("%A %d. %B %Y at %H:%M:%S"),
             ),
         )


### PR DESCRIPTION
Right now this line appears in the embed as "ID: `<built-in function id>`". I'm guessing this was meant to be the guild's ID?