### PR TITLE
Fix overlapping stat ranges for legendary crates

### DIFF
--- a/cogs/crates.py
+++ b/cogs/crates.py
@@ -111,10 +111,10 @@ class Crates(commands.Cog):
             else:
                 minstat, maxstat = (30, 34)
         elif rarity == "legendary":  # no else because why
-            if rand < 2:  # 20% 48-50
-                minstat, maxstat = (48, 50)
-            elif rand < 5:  # 30% 45-48
-                minstat, maxstat = (45, 48)
+            if rand < 2:  # 20% 49-50
+                minstat, maxstat = (49, 50)
+            elif rand < 5:  # 30% 46-48
+                minstat, maxstat = (46, 48)
             else:  # 50% 41-45
                 minstat, maxstat = (41, 45)
 


### PR DESCRIPTION
For the other crate rarities, the min/max ranges don't overlap with each other. For some reason they do with legendary - 45 was included in both the 2nd and 3rd blocks, while 48 was present in both the first and second blocks. This should fix that.