### PR TITLE
$child: Minor change to random chance

### DIFF
--- a/cogs/marriage.py
+++ b/cogs/marriage.py
@@ -327,7 +327,7 @@ class Marriage(commands.Cog):
         ):
             return await ctx.send(_("O.o not in the mood today?"))
 
-        if random.randint(1, 2) == 1:
+        if random.choice([True, False]):
             return await ctx.send(_("You were unsuccessful at making a child."))
         gender = random.choice(["m", "f"])
         if gender == "m":


### PR DESCRIPTION
It turns out, using `random.choice` here is about 30% faster, lol.

```py
>>> from timeit import timeit as tt
>>> tt("random.randint(1,2)==1","import random")
1.910611495000012
>>> tt("random.choice([True,False])","import random")
1.3157643509999843
```

Alternatives, if you're curious:
```py
>>> tt("random.choice([0,1])","import random")
1.3153014189999794
>>> tt("random.randint(0,1)","import random")
1.9065900620000207
```
