### PR TITLE
Fix adventure success calculation

### DIFF
--- a/utils/misc.py
+++ b/utils/misc.py
@@ -74,8 +74,8 @@ def xptonextlevel(xp):
 def calcchance(sword, shield, dungeon, level, luck, returnsuccess=False, booster=False):
     if returnsuccess is False:
         return (
-            round(sword + shield + 75 - (dungeon * 10) * luck),
-            round(sword + shield + 75 - (dungeon * 2) * luck),
+            round((sword + shield + 75 - dungeon * 10) * luck),
+            round((sword + shield + 75 - dungeon * 2) * luck),
             level,
         )
     else:


### PR DESCRIPTION
Fixes #204.

Note that the only fault with this is that if the chance of success is negative, multiplying it by the luck is only going to make it *more* negative.