### PR TITLE
New command imgur/shorten

### DIFF
--- a/cogs/miscellaneous/__init__.py
+++ b/cogs/miscellaneous/__init__.py
@@ -122,7 +122,36 @@ class Miscellaneous(commands.Cog):
                 color=0xF1C60C,
             )
         )
-
+        
+    @commands.command(aliases=["shorten"])
+    @locale_doc
+    async def imgur(self, ctx, given_url = None):
+        _("""Gives you a short URL from an image or long URL""")
+        if not given_url and not ctx.message.attachments:
+            return await ctx.send(_("Please supply a URL or an image attachment"))
+        if ctx.message.attachments:
+            if len(ctx.message.attachments) > 1:
+                return await ctx.send(_("Please only use one image at a time."))
+            url = ctx.message.attachments[0].url
+            if not (
+                url.endswith(".png") or url.endswith(".jpg") or url.endswith(".jpeg")
+            ):
+                return await ctx.send(_("This is not a valid image file."))
+            given_url = url
+            
+        async with self.bot.trusted_session.post(
+            "https://api.imgur.com/3/image"
+            headers={"Authorization":f"Client-ID {self.bot.config.imgur_token}"},
+            data={"image":given_url}
+        ) as r:
+            try:
+                link = (await r.json())["data"]["link"]
+            except KeyError:
+                return await ctx.send(_("Error when uploading to Imgur."))
+        await ctx.send(
+            _(f"Here's your short image URL: <{link}>")
+        )
+        
     @commands.command(aliases=["donate"])
     @locale_doc
     async def patreon(self, ctx):
@@ -609,7 +638,7 @@ Average hours of work: **{hours}**"""
     @commands.command()
     @locale_doc
     async def garfield(
-        self, ctx, *, date: DateOrToday(datetime.date(year=1978, month=6, day=19))
+        self, ctx, date: DateOrToday(datetime.date(year=1978, month=6, day=19))
     ):
         _(
             """Sends today's garfield comic if no date info is passed. Else, it will use YYYY MM DD or DD MM YYYY depending on where the year is, with the date parts being seperated with spaces."""
@@ -623,7 +652,7 @@ Average hours of work: **{hours}**"""
     @commands.command(aliases=["uf"])
     @locale_doc
     async def userfriendly(
-        self, ctx, *, date: DateOrToday(datetime.date(year=1997, month=11, day=17))
+        self, ctx, date: DateOrToday(datetime.date(year=1997, month=11, day=17))
     ):
         _(
             """Sends today's userfriendly comic if no date info is passed. Else, it will use YYYY MM DD or DD MM YYYY depending on where the year is, with the date parts being seperated with spaces."""

--- a/cogs/miscellaneous/__init__.py
+++ b/cogs/miscellaneous/__init__.py
@@ -139,7 +139,7 @@ class Miscellaneous(commands.Cog):
                 return await ctx.send(_("This is not a valid image file."))
             given_url = url
             
-        async with self.bot.trusted_session.post(
+        async with self.bot.session.post(
             "https://api.imgur.com/3/image"
             headers={"Authorization":f"Client-ID {self.bot.config.imgur_token}"},
             data={"image":given_url}
@@ -149,7 +149,7 @@ class Miscellaneous(commands.Cog):
             except KeyError:
                 return await ctx.send(_("Error when uploading to Imgur."))
         await ctx.send(
-            _(f"Here's your short image URL: <{link}>")
+            _(f"Here's your short image URL: <{link}>").format(link=link)
         )
         
     @commands.command(aliases=["donate"])


### PR DESCRIPTION
since a lot of people have problems getting short URLs from image hosting sites or are just plain too lazy, I've decided to add this command.
if i didn't screw anything up, this command will:
-upload an image to imgur based off the given url or a picture attachment
-return a short url that can be used for `$guild icon` for example

if you don't want to include it, i can remove the part with `given_url`, since commands that take urls have a restriction for less than 60 characters