### PR TITLE
command list aliases

### DIFF
--- a/cogs/help/__init__.py
+++ b/cogs/help/__init__.py
@@ -100,7 +100,7 @@ class Help(commands.Cog):
             pages.append(embed)
         return pages
 
-    @commands.command()
+    @commands.command(alieses=["commands", "cmds"])
     @locale_doc
     async def documentation(self, ctx):
         _("""Sends a link to the official documentation.""")


### PR DESCRIPTION
because I've noticed a lot of people using `$commands` to try and get the command list