### PR TITLE
Transaction: Add brackets around each subcommand

### DIFF
--- a/cogs/transaction/__init__.py
+++ b/cogs/transaction/__init__.py
@@ -85,7 +85,7 @@ class Transaction(commands.Cog):
             content
             + "\n\n"
             + _(
-                "Use `{prefix}trade add/set/remove money/crates/item amount/itemid [crate rarity]`"
+                "Use `{prefix}trade [add/set/remove] [money/crates/item] [amount/itemid] [crate rarity]`"
             ).format(prefix=ctx.prefix)
         )
         if (base := self.transactions[id_]["base"]) is not None:


### PR DESCRIPTION
I'll admit that it took me a few tries to get this right because I couldn't easily see where the required parts were. This might make it a bit easier to read.