### PR TITLE
Fix Ranger bug

### DIFF
--- a/classes/bot.py
+++ b/classes/bot.py
@@ -400,7 +400,7 @@ class Bot(commands.AutoShardedBot):
         return item
 
     def in_class_line(self, classes, line):
-        return any([self.get_class_line(c) == line for c in classes])
+        return any([self.get_class_line(c) == line for c in list(classes)])
 
     def get_class_grade_from(self, classes, line):
         for class_ in classes:


### PR DESCRIPTION
As you sometimes pass a string for the classes var in in_class_line I would suggest either locally converting the classes to a list in every case or always pass it as a list everywhere from the code. Else it will try to match the single characters and will obviously fail. Tested thru eval, works.

`$eval return ((check := ctx.bot.in_class_line(["Bowman"], "Ranger")), check)` --> `(True, True)`
`$eval return ((check := ctx.bot.in_class_line("Bowman", "Ranger")), check)`--> `(False, False)`