### PR TITLE
admin command to reset a user's class(es)

### DIFF
--- a/cogs/admin/__init__.py
+++ b/cogs/admin/__init__.py
@@ -204,6 +204,28 @@ class Admin(commands.Cog):
             self.bot.config.admin_log_channel,
             f"**{ctx.author}** reset **{target}**'s donator perks.",
         )
+        
+    @is_admin()
+    @commands.command(aliases=["aresetclass"], hidden=True)
+    @locale_doc
+    async def adminresetclass(self, ctx, target: UserWithCharacter):
+        _("""[Bot Admin only] Resets someone's class(es).""")
+        async with self.bot.pool.acquire() as conn:
+            await conn.execute(
+                '''UPDATE profile SET "class"='{"No Class", "No Class"}' WHERE "user"=$1;''',
+                target.id
+            )
+        
+        await ctx.send(
+            _(
+                "Successfully reset {target}'s class."
+            ).format(target=target)
+        
+        )
+        await self.bot.http.send_message(
+            self.bot.config.admin_log_channel,
+            f"**{ctx.author}** reset **{target}**'s class.",
+        )
 
 
 def setup(bot):


### PR DESCRIPTION
I've seen some users still with the "Pet in Purgatory" bug, as I like to call it, where the pet is gone but the class is not reset.