### PR TITLE
add paginator to family

### DIFF
--- a/cogs/marriage/__init__.py
+++ b/cogs/marriage/__init__.py
@@ -411,7 +411,7 @@ class Marriage(commands.Cog):
             await ctx.send(embed=em)
         else:
             embeds = []
-            children_lists = list(self.make_chunks(children, 5))
+            children_lists = list(self.make_chunks(children, 9))
             for small_list in children_lists:
                 em = discord.Embed(
                     title=_("Your family"),
@@ -425,7 +425,7 @@ class Marriage(commands.Cog):
                         value=_("Gender: {gender}, Age: {age}").format(
                             gender=child["gender"], age=child["age"]
                         ),
-                        inline=False,
+                        inline=True,
                     )
                 embeds.append(em)
             await self.bot.paginator.Paginator(extras=embeds).paginate(ctx)

--- a/cogs/marriage/__init__.py
+++ b/cogs/marriage/__init__.py
@@ -25,6 +25,7 @@ from discord.ext.commands.default import Author
 
 from classes.converters import IntFromTo, MemberWithCharacter, UserWithCharacter
 from cogs.shard_communication import user_on_cooldown as user_cooldown
+from cogs.help import chunks
 from utils import misc as rpgtools
 from utils.checks import has_char
 
@@ -371,11 +372,6 @@ class Marriage(commands.Cog):
             )
         await ctx.send(_("{name} was born.").format(name=name))
 
-    def make_chunks(self, child_list: list, size: int):
-        """splits children into smaller list for pagination"""
-        for i in range(0, len(child_list), size):
-            yield child_list[i : i + size]
-
     @has_char()
     @commands.command()
     @locale_doc
@@ -411,7 +407,7 @@ class Marriage(commands.Cog):
             await ctx.send(embed=em)
         else:
             embeds = []
-            children_lists = list(self.make_chunks(children, 9))
+            children_lists = list(chunks(children, 9))
             for small_list in children_lists:
                 em = discord.Embed(
                     title=_("Your family"),


### PR DESCRIPTION
Suggested by user *∞ 👹๖̶̶̶ζ͜͡Dont Meζۜۜ͜๖ 👹∞#8858*.

When having more than 10 children, the family embed can become a real mess. Added onto that, embeds have a limit of 25 fields, and, seeing how Don has 27 children, some children can not be displayed.

The way this is intended to work is, when a user has more than 5 children, the new function `make_chunks` kicks in, dividing children into smaller list with 5 children each, that get devided into their own embeds (would be six embeds in Don's case). These embeds will then be paginated.

This will make the `$family` embed not take up 3 whole screens for users with a lot of children, as well as prevent children from not being displayed.

Please note that I'm not too familiar with the Paginator, so take a careful look at it before merging. 