### PR TITLE
update transaction description length

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -42,7 +42,7 @@ SET default_table_access_method = heap;
 CREATE TABLE public.allitems (
     id bigint NOT NULL,
     owner bigint,
-    name character varying(200) NOT NULL,
+    name character varying(575) NOT NULL,
     value integer NOT NULL,
     type character varying(10) NOT NULL,
     damage numeric(5,2) NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -42,7 +42,7 @@ SET default_table_access_method = heap;
 CREATE TABLE public.allitems (
     id bigint NOT NULL,
     owner bigint,
-    name character varying(575) NOT NULL,
+    name character varying(200) NOT NULL,
     value integer NOT NULL,
     type character varying(10) NOT NULL,
     damage numeric(5,2) NOT NULL,
@@ -328,7 +328,7 @@ CREATE TABLE public.transactions (
     "from" bigint NOT NULL,
     "to" bigint NOT NULL,
     subject character varying(50) NOT NULL,
-    info character varying(200) NOT NULL,
+    info character varying(582) NOT NULL,
     "timestamp" timestamp with time zone NOT NULL
 );
 


### PR DESCRIPTION
As seen in #353 

How do I get to this number? Let's see:
79 characters [bare message](https://github.com/Gelbpunkt/IdleRPG/blob/v4/classes/bot.py#L648-L658) length without any info in braces
100 characters potential server name length
100 characters potential channel name length
2 \* 32 characters potential Discord Tag length (+5 discrim for each), so 74
5 characters (length of word "offer")
200 characters [potential item name length](https://github.com/Gelbpunkt/IdleRPG/blob/v4/schema.sql#L45)
8 characters length of Item ID (we'll consider the items to go to the 10millions soon)
6 characters (length of word "shield")
2 \* 5 characters lengths for both damage and defense (ex. "12.00")

Note: this is to completely avoid transactions not logging. I know that this will make the database grow a lot in size. Considering that most users don't have 100 character servers/channels, 200 character long item names or 32 character usernames, this number can and should be brought down significantly, but we need to discuss that.