### PR TITLE
use confirms for class selection/change

### DIFF
--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -131,9 +131,9 @@ class Classes(commands.Cog):
             _(
                 "You are about to select the `{profession}` class for yourself. {textaddon}Proceed?"
             ).format(
-                textaddon="This will cost **$5000**. "
+                textaddon=_("This will cost **$5000**. ")
                 if ctx.character_data["class"][val] == "No Class"
-                else "Changing it later will cost **$5000**. "
+                else _("Changing it later will cost **$5000**. ")
             )
         ):
             await self.bot.reset_cooldown(ctx)

--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -131,7 +131,9 @@ class Classes(commands.Cog):
             _(
                 "You are about to select the `{profession}` class for yourself. {textaddon}Proceed?"
             ).format(
-                textaddon="This will cost **$5000**. " if ctx.character_data["class"][val] == "No Class" else "Changing it later will cost **$5000**. "
+                textaddon="This will cost **$5000**. "
+                if ctx.character_data["class"][val] == "No Class"
+                else "Changing it later will cost **$5000**. "
             )
         ):
             await self.bot.reset_cooldown(ctx)

--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -130,6 +130,15 @@ class Classes(commands.Cog):
         new_classes = copy(ctx.character_data["class"])
         new_classes[val] = profession_
         if ctx.character_data["class"][val] == "No Class":
+            conf = await ctx.confirm(
+                _(
+                    "You are about to select the `{profession}` class for yourself, changing it later will cost **$5000**. Proceed?"
+                ).format(profession=profession,)
+            )
+            if not conf:
+                await self.bot.reset_cooldown(ctx)
+                await conf.delete()
+                return await ctx.send(_("Class selection cancelled."))
             async with self.bot.pool.acquire() as conn:
                 await conn.execute(
                     'UPDATE profile SET "class"=$1 WHERE "user"=$2;',
@@ -146,6 +155,15 @@ class Classes(commands.Cog):
                 )
             )
         else:
+            conf = await ctx.confirm(
+                _(
+                    "You are about to change to the `{profession}` class, this will cost **$5000**. Proceed?"
+                ).format(profession=profession,)
+            )
+            if not conf:
+                await self.bot.reset_cooldown(ctx)
+                await conf.delete()
+                return await ctx.send(_("Class change cancelled."))
             if not await self.bot.has_money(ctx.author.id, 5000):
                 await self.bot.reset_cooldown(ctx)
                 return await ctx.send(

--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -127,16 +127,16 @@ class Classes(commands.Cog):
             profession_ = "Priest"
         new_classes = copy(ctx.character_data["class"])
         new_classes[val] = profession_
-        if ctx.character_data["class"][val] == "No Class":
-            conf = await ctx.confirm(
-                _(
-                    "You are about to select the `{profession}` class for yourself, changing it later will cost **$5000**. Proceed?"
-                ).format(profession=profession)
+        if not await ctx.confirm(
+            _(
+                "You are about to select the `{profession}` class for yourself. {textaddon}Proceed?"
+            ).format(
+                textaddon="This will cost **$5000**. " if ctx.character_data["class"][val] == "No Class" else "Changing it later will cost **$5000**. "
             )
-            if not conf:
-                await self.bot.reset_cooldown(ctx)
-                await conf.delete()
-                return await ctx.send(_("Class selection cancelled."))
+        ):
+            await self.bot.reset_cooldown(ctx)
+            return await ctx.send(_("Class selection cancelled."))
+        if ctx.character_data["class"][val] == "No Class":
             async with self.bot.pool.acquire() as conn:
                 await conn.execute(
                     'UPDATE profile SET "class"=$1 WHERE "user"=$2;',
@@ -153,15 +153,6 @@ class Classes(commands.Cog):
                 )
             )
         else:
-            conf = await ctx.confirm(
-                _(
-                    "You are about to change to the `{profession}` class, this will cost **$5000**. Proceed?"
-                ).format(profession=profession)
-            )
-            if not conf:
-                await self.bot.reset_cooldown(ctx)
-                await conf.delete()
-                return await ctx.send(_("Class change cancelled."))
             if not await self.bot.has_money(ctx.author.id, 5000):
                 await self.bot.reset_cooldown(ctx)
                 return await ctx.send(

--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -129,11 +129,11 @@ class Classes(commands.Cog):
         new_classes[val] = profession_
         if not await ctx.confirm(
             _(
-                "You are about to select the `{profession}` class for yourself. {textaddon}Proceed?"
+                "You are about to select the `{profession}` class for yourself. {textaddon} Proceed?"
             ).format(
-                textaddon=_("This will cost **$5000**. ")
+                textaddon=_("This will cost **$5000**.")
                 if ctx.character_data["class"][val] == "No Class"
-                else _("Changing it later will cost **$5000**. ")
+                else _("Changing it later will cost **$5000**.")
             )
         ):
             await self.bot.reset_cooldown(ctx)

--- a/cogs/classes/__init__.py
+++ b/cogs/classes/__init__.py
@@ -16,12 +16,10 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import secrets
-
 from copy import copy
 from decimal import Decimal
 
 import discord
-
 from discord.ext import commands
 
 from cogs.shard_communication import user_on_cooldown as user_cooldown
@@ -133,7 +131,7 @@ class Classes(commands.Cog):
             conf = await ctx.confirm(
                 _(
                     "You are about to select the `{profession}` class for yourself, changing it later will cost **$5000**. Proceed?"
-                ).format(profession=profession,)
+                ).format(profession=profession)
             )
             if not conf:
                 await self.bot.reset_cooldown(ctx)
@@ -158,7 +156,7 @@ class Classes(commands.Cog):
             conf = await ctx.confirm(
                 _(
                     "You are about to change to the `{profession}` class, this will cost **$5000**. Proceed?"
-                ).format(profession=profession,)
+                ).format(profession=profession)
             )
             if not conf:
                 await self.bot.reset_cooldown(ctx)


### PR DESCRIPTION
Suggested by DontMe

New players might not know about the cost for class changes, and when they're changing classes, their money will just be removed unprompted. This pull request fixes that. Confirmation dialogues are used to inform the player about that.