### PR TITLE
consistency in resetting cooldowns

### DIFF
--- a/cogs/adventure/__init__.py
+++ b/cogs/adventure/__init__.py
@@ -119,7 +119,7 @@ class Adventure(commands.Cog):
                 "You are going to be in a labyrinth of size 15x15. There are enemies, treasures and hidden traps. Reach the exit in the bottom right corner for a huge extra bonus!\nAre you ready?\n\nTip: Use a silent channel for this, you may want to read all the messages I will send."
             )
         ):
-            return
+            return await self.bot.reset_cooldown(ctx)
 
         msg = await ctx.send(_("**Generating a maze...**"))
 

--- a/cogs/guild/__init__.py
+++ b/cogs/guild/__init__.py
@@ -209,7 +209,7 @@ class Guild(commands.Cog):
         if not await ctx.confirm(
             _("Are you sure? React to create a guild for **$10000**")
         ):
-            return
+            return await self.bot.reset_cooldown(ctx)
         if not await has_money(self.bot, ctx.author.id, 10000):
             return await ctx.send(
                 _("A guild creation costs **$10000**, you are too poor.")
@@ -655,6 +655,7 @@ class Guild(commands.Cog):
             timeout=60,
             user=enemy,
         ):
+            await self.bot.reset_cooldown(ctx)
             return await ctx.send(
                 _("{enemy} didn't want to join your battle, {author}.").format(
                     enemy=enemy.mention, author=ctx.author.mention

--- a/cogs/marriage/__init__.py
+++ b/cogs/marriage/__init__.py
@@ -330,6 +330,7 @@ class Marriage(commands.Cog):
             ),
             user=user,
         ):
+            await self.bot.reset_cooldown(ctx)
             return await ctx.send(_("O.o not in the mood today?"))
 
         if random.choice([True, False]):

--- a/cogs/trading/__init__.py
+++ b/cogs/trading/__init__.py
@@ -260,7 +260,8 @@ class Trading(commands.Cog):
                     item=item["name"]
                 )
             ):
-                await ctx.send(_("Item selling cancelled."))
+                await self.bot.reset_cooldown(ctx)
+                return await ctx.send(_("Item selling cancelled."))
 
         if not await ctx.confirm(
             _(
@@ -269,6 +270,7 @@ class Trading(commands.Cog):
             user=user,
             timeout=120,
         ):
+            await self.bot.reset_cooldown(ctx)
             return await ctx.send(_("They didn't want it."))
 
         if not await has_money(self.bot, user.id, price):
@@ -337,6 +339,7 @@ class Trading(commands.Cog):
                     ).format(amount=equipped),
                     timeout=6,
                 ):
+                    await self.bot.reset_cooldown(ctx)
                     return await ctx.send(_("Cancelled."))
             await conn.execute(
                 'DELETE FROM allitems WHERE "id"=ANY($1) AND "owner"=$2;',
@@ -385,7 +388,7 @@ class Trading(commands.Cog):
                     "You are about to sell **{count} items!**\nAre you sure you want to do this?"
                 ).format(count=count)
             ):
-                return
+                return await self.bot.reset_cooldown(ctx)
             async with conn.transaction():
                 await conn.execute(
                     "DELETE FROM allitems ai USING inventory i WHERE ai.id=i.item AND ai.owner=$1 AND i.equipped IS FALSE AND ai.armor+ai.damage BETWEEN $2 AND $3;",


### PR DESCRIPTION
Seen some reports that denying thee `$merchall` textbox still had the cooldown, so I decided to fix that. In the process, I also found some more cases like this and added `bot.reset_cooldown()` to those too.